### PR TITLE
PARAM_MULTILANG is deprecated in favor of PARAM_TEXT

### DIFF
--- a/edit_form.php
+++ b/edit_form.php
@@ -10,7 +10,7 @@ class block_newblock_edit_form extends block_edit_form {
         // A sample string variable with a default value.
         $mform->addElement('text', 'config_text', get_string('blockstring', 'block_newblock'));
         $mform->setDefault('config_text', 'default value');
-        $mform->setType('config_text', PARAM_MULTILANG);        
+        $mform->setType('config_text', PARAM_TEXT);        
 
     }
 }


### PR DESCRIPTION
Tiny update (more info: https://github.com/moodle/moodle/blob/master/lib/moodlelib.php#L286-L290)
